### PR TITLE
Linking to libs that are required if you want to 'hot-load' some code

### DIFF
--- a/src/ciWMFVideoPlayerUtils.cpp
+++ b/src/ciWMFVideoPlayerUtils.cpp
@@ -19,6 +19,11 @@
 #pragma comment(lib, "Shlwapi.lib")
 #pragma comment(lib, "Propsys.lib")
 
+// These three libs are required if you want to 'hot-load' some code that uses Cinder-WMFVideo
+#pragma comment(lib, "User32.lib") 
+#pragma comment(lib, "Ole32.lib") 
+#pragma comment(lib, "Gdi32.lib") 
+
 #include "presenter/Presenter.h"
 #include "atlcomcli.h"
 


### PR DESCRIPTION
… that uses Cinder-WMFVideo

ex. with [Cinder-Runtime](https://github.com/simongeilfus/Cinder-Runtime/blob/master/include/runtime/Factory.h#L277).

These only seem necessary from a .dll that is runtime loaded and uses the code in this block, but they are clearly used by something in the library so this code is harmless for the regular case.